### PR TITLE
Add verified Codex and Grok image-engine hints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,8 +13,8 @@
     {
       "name": "image-gen",
       "source": "./",
-      "description": "Cover images and in-article illustrations. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback.",
-      "version": "2.0.0",
+      "description": "Cover images and in-article illustrations. Imagen direct adapter and Grok or Codex engine hints.",
+      "version": "2.1.0",
       "author": {
         "name": "Spillwave Solutions"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "image-gen",
   "displayName": "Image Gen",
-  "version": "2.0.0",
-  "description": "Cover images and in-article illustrations. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback.",
+  "version": "2.1.0",
+  "description": "Cover images and in-article illustrations. Imagen direct adapter and Grok or Codex engine hints.",
   "author": {
     "name": "Spillwave Solutions",
     "email": "rick@spillwave.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -24,7 +24,7 @@
   "interface": {
     "displayName": "Image Gen",
     "shortDescription": "Cover and in-article images via imagen, grok, or Codex",
-    "longDescription": "Generate article cover images and technical illustrations. Use Imagen directly or select Grok and Codex agent hosts with an engine hint. Every host must write the requested PNG or the run fails closed with a prompt sidecar.",
+    "longDescription": "Generate article cover images and technical illustrations. Use Imagen or grok-img directly, or select the Codex agent host with an engine hint. Every engine must write the requested PNG or the run fails closed with a prompt sidecar.",
     "developerName": "Spillwave Solutions",
     "category": "Productivity",
     "capabilities": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-gen",
-  "version": "2.0.0",
-  "description": "Cover images and in-article illustrations for Codex. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback.",
+  "version": "2.1.0",
+  "description": "Cover images and in-article illustrations for Codex. Imagen direct adapter and Grok or Codex engine hints.",
   "author": {
     "name": "Spillwave Solutions",
     "email": "rick@spillwave.com",
@@ -24,7 +24,7 @@
   "interface": {
     "displayName": "Image Gen",
     "shortDescription": "Cover and in-article images via imagen, grok, or Codex",
-    "longDescription": "Generate article cover images and technical illustrations. Installs the latest imagen CLI, pins Nano Banana 2 / Pro, and falls back to grok then Codex. Fail closed writes a prompt sidecar.",
+    "longDescription": "Generate article cover images and technical illustrations. Use Imagen directly or select Grok and Codex agent hosts with an engine hint. Every host must write the requested PNG or the run fails closed with a prompt sidecar.",
     "developerName": "Spillwave Solutions",
     "category": "Productivity",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-gen",
-  "version": "2.0.0",
-  "description": "Cover images and in-article illustrations. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback.",
+  "version": "2.1.0",
+  "description": "Cover images and in-article illustrations. Imagen direct adapter and Grok or Codex engine hints.",
   "author": {
     "name": "Spillwave Solutions"
   },

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "spillwave-image-gen",
   "description": "Optional native Grok marketplace metadata. Grok Build already loads Claude plugins with zero config.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "plugins": [
     {
       "name": "image-gen",
       "source": ".",
-      "description": "Cover images and in-article illustrations. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback. Claude-compatible.",
-      "version": "2.0.0",
+      "description": "Cover images and in-article illustrations. Imagen direct adapter and Grok or Codex engine hints. Claude-compatible.",
+      "version": "2.1.0",
       "compatibility": {
         "claude_plugin": true,
         "zero_config": true

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-gen",
-  "version": "2.0.0",
-  "description": "Cover images and in-article illustrations. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback.",
+  "version": "2.1.0",
+  "description": "Cover images and in-article illustrations. Imagen direct adapter and Grok or Codex engine hints.",
   "author": {
     "name": "Spillwave Solutions",
     "email": "rick@spillwave.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 Article cover and in-article image plugin.
 
 - Not the diagram renderer. Mermaid / PlantUML belongs in imagen-diagrams.
-- Backend auto: imagen, then grok, then codex. Fail closed writes `<stem>_imagen.prompt.txt` and exits 2.
+- Backend auto: Imagen, then Grok agent, then Codex agent. `--engine-hint`
+  explicitly selects one. The agent runners must write the PNG or fail closed.
 - Brace policy is per backend. Never copy the wrong escape.
 - Install latest `gemini-imagen` with `skills/image-gen/scripts/install_imagen.py`.
 - Default model is Nano Banana 2 (`gemini-3.1-flash-image`). Covers use Nano Banana Pro.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 Article cover and in-article image plugin.
 
 - Not the diagram renderer. Mermaid / PlantUML belongs in imagen-diagrams.
-- Backend auto: Imagen, then Grok agent, then Codex agent. `--engine-hint`
-  explicitly selects one. The agent runners must write the PNG or fail closed.
+- Backend auto: Imagen, then grok-img, then Codex agent. `--engine-hint`
+  explicitly selects one. grok-img and Codex must write the PNG or fail closed.
 - Brace policy is per backend. Never copy the wrong escape.
 - Install latest `gemini-imagen` with `skills/image-gen/scripts/install_imagen.py`.
 - Default model is Nano Banana 2 (`gemini-3.1-flash-image`). Covers use Nano Banana Pro.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 2.1.0
 
 - Add `--engine-hint imagen|grok|codex`.
-- Run Grok Build and Codex as agents that use their native image tools, then
-  verify they wrote the requested PNG.
+- Map the Grok hint to grok-img, use an isolated output directory, and
+  normalize its generated image to the requested PNG path.
+- Run Codex as an agent that uses its native image tool, then verify it wrote
+  the requested PNG.
 - Auto mode now falls through when an installed engine fails at runtime, such
   as an unconfigured Imagen CLI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0
+
+- Add `--engine-hint imagen|grok|codex`.
+- Run Grok Build and Codex as agents that use their native image tools, then
+  verify they wrote the requested PNG.
+- Auto mode now falls through when an installed engine fails at runtime, such
+  as an unconfigured Imagen CLI.
+
 ## 2.0.0
 
 - Ship as a Claude Code, Codex, Grok Build, Cursor, and Agent Plugins v1 plugin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,13 @@ python3 -m unittest discover -s tests -v
 ## Backend auto
 
 1. `imagen` on PATH. Policy `imagen-cli-vars`.
-2. Else `grok`. Policy `grok-imagine`.
-3. Else `codex`. Policy `grok-imagine`.
+2. Then Grok Build agent. Policy `grok-imagine`.
+3. Then Codex agent. Policy `grok-imagine`.
 4. Else write `<stem>_imagen.prompt.txt` and exit 2.
+
+Use `--engine-hint imagen|grok|codex` to select a runner. Grok and Codex are
+agent-host adapters, not imaginary `image generate` subcommands. Both must
+write the requested PNG for a run to pass.
 
 ## Models
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,13 @@ python3 -m unittest discover -s tests -v
 ## Backend auto
 
 1. `imagen` on PATH. Policy `imagen-cli-vars`.
-2. Then Grok Build agent. Policy `grok-imagine`.
+2. Then `grok-img`. Policy `grok-imagine`.
 3. Then Codex agent. Policy `grok-imagine`.
 4. Else write `<stem>_imagen.prompt.txt` and exit 2.
 
-Use `--engine-hint imagen|grok|codex` to select a runner. Grok and Codex are
-agent-host adapters, not imaginary `image generate` subcommands. Both must
-write the requested PNG for a run to pass.
+Use `--engine-hint imagen|grok|codex` to select a runner. `grok` maps to
+grok-img. Codex is an agent-host adapter, not an imaginary `image generate`
+subcommand. Both must write the requested PNG for a run to pass.
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,24 @@ Hosts: **Claude Code**, **Codex**, **Grok Build**, **Cursor**, **SKILZ / Agent P
 
 Not the diagram renderer. Mermaid and PlantUML go to [`imagen-diagrams`](https://github.com/SpillwaveSolutions/imagen-diagrams).
 
-## Backend (auto)
+## Image-engine hint and backend (auto)
+
+To direct a generation through a specific host, pass one of:
+
+```bash
+--engine-hint imagen
+--engine-hint grok
+--engine-hint codex
+```
+
+`imagen` is a direct CLI adapter. `grok` and `codex` are agent adapters: the
+plugin sends the art brief to the host and requires it to save a PNG to the
+requested output path. If the host returns prose without a file, the command
+fails closed and retains the prompt sidecar. With no hint, auto mode tries the
+available engines in order and continues after an authentication or runtime
+failure.
+
+## Backend order (auto)
 
 1. `imagen` CLI if on PATH. Brace policy: `imagen-cli-vars` (double `{` `}`).
 2. Else `grok` CLI. Brace policy: `grok-imagine` (no rewrite).

--- a/README.md
+++ b/README.md
@@ -23,17 +23,26 @@ To direct a generation through a specific host, pass one of:
 --engine-hint codex
 ```
 
-`imagen` is a direct CLI adapter. `grok` and `codex` are agent adapters: the
-plugin sends the art brief to the host and requires it to save a PNG to the
-requested output path. If the host returns prose without a file, the command
-fails closed and retains the prompt sidecar. With no hint, auto mode tries the
-available engines in order and continues after an authentication or runtime
-failure.
+`imagen` and `grok-img` are direct CLI adapters. `codex` is an agent adapter:
+the plugin asks Codex to save a PNG to the requested output path. `grok-img`
+renders into an isolated staging directory and the plugin normalizes its image
+to the requested path. A missing result fails closed and retains the prompt
+sidecar. With no hint, auto mode tries the available engines in order and
+continues after an authentication or runtime failure.
+
+The official interactive Grok Build TUI supports `/imagine <prompt>`, but it
+saves a session image rather than accepting a requested output path. Use
+`grok-img` for the scriptable adapter:
+
+```bash
+npm install -g grok-image-cli
+grok-img auth login
+```
 
 ## Backend order (auto)
 
 1. `imagen` CLI if on PATH. Brace policy: `imagen-cli-vars` (double `{` `}`).
-2. Else `grok` CLI. Brace policy: `grok-imagine` (no rewrite).
+2. Then `grok-img` CLI. Brace policy: `grok-imagine` (no rewrite).
 3. Else `codex` CLI. Brace policy: `grok-imagine` (no rewrite).
 4. Else fail closed. Writes `<stem>_imagen.prompt.txt` and exits 2.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 name: image-gen
 description: >
   Generate cover images and in-article illustrations for technical articles.
-  Auto image backend: imagen CLI (Nano Banana 2 / Pro), else grok, else codex.
+  Auto image backend: Imagen CLI (Nano Banana 2 / Pro), Grok agent, then Codex agent.
   Triggers: generate images, cover image, article illustrations, visual assets,
   imagen, nano banana, grok imagine.
 ---
@@ -17,7 +17,21 @@ Use this skill when the user wants a cover image, in-article illustration, or vi
 
 Do not use this skill to render Mermaid or PlantUML. Send those to `imagen-diagrams`.
 
-## Backend (auto)
+## Image-engine hint and backend (auto)
+
+Use `--engine-hint imagen`, `--engine-hint grok`, or `--engine-hint codex`
+when a caller has a preferred image engine. The hint chooses a real execution
+path, not a guessed subcommand.
+
+- **Imagen** calls the `imagen` CLI directly.
+- **Grok** starts a Grok Build agent and asks its native image tool to save the
+  requested PNG.
+- **Codex** starts a Codex agent and asks `image_gen` to save the requested PNG.
+
+Grok and Codex must actually create the file. A prose-only response fails
+closed, leaves the prompt sidecar, and records the failed attempt. With no
+hint, auto tries every installed engine in this order and continues after a
+runtime or authentication failure.
 
 1. `imagen` CLI if on PATH. Brace policy: `imagen-cli-vars` (double braces).
 2. Else `grok` CLI. Brace policy: `grok-imagine` (no rewrite).
@@ -77,6 +91,14 @@ python3 skills/image-gen/scripts/generate.py \
   --aspect 16:9 \
   --output work/images/article_workflow.png \
   --prompt "A clean technical diagram showing [concept] with color-coded arrows and clear labels. Style: blueprint, professional."
+
+# Prefer the Codex host's native image generation.
+python3 skills/image-gen/scripts/generate.py \
+  --kind article \
+  --engine-hint codex \
+  --aspect 16:9 \
+  --output work/images/article_workflow.png \
+  --prompt "A clean technical diagram showing [concept]."
 ```
 
 ### 4. Integrate + ALT text
@@ -89,7 +111,8 @@ Cover immediately after H1. In-article images at section breaks. ALT text 50–1
 
 ### 5. Verify
 
-PNG exists. Sidecar `*.json` records backend, policy, model. Prompt sidecar kept next to the PNG.
+PNG exists. Sidecar `*.json` records engine hint, backend, policy, model, and
+every attempted engine. Prompt sidecar is kept next to the PNG.
 
 ## Scripts
 
@@ -116,6 +139,6 @@ Nano Banana Pro renders in-image text more reliably than Flash. Ask for "clear l
 
 - `<stem>.png` (or the `--output` path)
 - `<stem>_imagen.prompt.txt` (always)
-- `<stem>.json` sidecar (backend, policy, model)
+- `<stem>.json` sidecar (engine hint, backend, policy, model, attempts)
 
 If the worker is missing, only the prompt sidecar is written and the process exits 2.

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 name: image-gen
 description: >
   Generate cover images and in-article illustrations for technical articles.
-  Auto image backend: Imagen CLI (Nano Banana 2 / Pro), Grok agent, then Codex agent.
+  Auto image backend: Imagen CLI (Nano Banana 2 / Pro), grok-img, then Codex agent.
   Triggers: generate images, cover image, article illustrations, visual assets,
   imagen, nano banana, grok imagine.
 ---
@@ -24,17 +24,17 @@ when a caller has a preferred image engine. The hint chooses a real execution
 path, not a guessed subcommand.
 
 - **Imagen** calls the `imagen` CLI directly.
-- **Grok** starts a Grok Build agent and asks its native image tool to save the
-  requested PNG.
+- **Grok** calls `grok-img`, the noninteractive xAI image CLI, then normalizes
+  its generated file to the requested output path.
 - **Codex** starts a Codex agent and asks `image_gen` to save the requested PNG.
 
-Grok and Codex must actually create the file. A prose-only response fails
-closed, leaves the prompt sidecar, and records the failed attempt. With no
-hint, auto tries every installed engine in this order and continues after a
-runtime or authentication failure.
+Grok and Codex must actually create the file. A prose-only Codex response or a
+missing grok-img result fails closed, leaves the prompt sidecar, and records the
+failed attempt. With no hint, auto tries every installed engine in this order
+and continues after a runtime or authentication failure.
 
 1. `imagen` CLI if on PATH. Brace policy: `imagen-cli-vars` (double braces).
-2. Else `grok` CLI. Brace policy: `grok-imagine` (no rewrite).
+2. Then `grok-img` CLI. Brace policy: `grok-imagine` (no rewrite).
 3. Else `codex` CLI. Brace policy: `grok-imagine` (no rewrite).
 4. Else fail closed. Write `<stem>_imagen.prompt.txt` and exit 2.
 
@@ -92,10 +92,11 @@ python3 skills/image-gen/scripts/generate.py \
   --output work/images/article_workflow.png \
   --prompt "A clean technical diagram showing [concept] with color-coded arrows and clear labels. Style: blueprint, professional."
 
-# Prefer the Codex host's native image generation.
+# Prefer the noninteractive grok-img CLI. Configure XAI_API_KEY or run
+# `grok-img auth login` first.
 python3 skills/image-gen/scripts/generate.py \
   --kind article \
-  --engine-hint codex \
+  --engine-hint grok \
   --aspect 16:9 \
   --output work/images/article_workflow.png \
   --prompt "A clean technical diagram showing [concept]."

--- a/commands/image-gen.md
+++ b/commands/image-gen.md
@@ -7,7 +7,10 @@ Run `skills/image-gen/scripts/generate.py`.
 1. Choose kind: cover (Nano Banana Pro, 16:9) or article (Nano Banana 2).
 2. Write a specific prompt. Covers are metaphorical. In-article images explain one concept.
 3. Call generate.py with `--output` under `work/images/`.
-4. If exit 2, no backend is on PATH. The prompt sidecar is already written. Run `/image-gen-install` or install grok/codex.
-5. Integrate the PNG with 50–125 character ALT text.
+4. Use `--engine-hint imagen|grok|codex` when the host matters. Grok and Codex
+   are agent runners and must write the requested PNG; prose-only results fail
+   closed with a retained prompt sidecar.
+5. If exit 2, no backend is on PATH. The prompt sidecar is already written. Run `/image-gen-install` or install grok/codex.
+6. Integrate the PNG with 50–125 character ALT text.
 
 Do not invent a PNG. Do not send Mermaid or PlantUML through this command.

--- a/commands/image-gen.md
+++ b/commands/image-gen.md
@@ -7,10 +7,11 @@ Run `skills/image-gen/scripts/generate.py`.
 1. Choose kind: cover (Nano Banana Pro, 16:9) or article (Nano Banana 2).
 2. Write a specific prompt. Covers are metaphorical. In-article images explain one concept.
 3. Call generate.py with `--output` under `work/images/`.
-4. Use `--engine-hint imagen|grok|codex` when the host matters. Grok and Codex
-   are agent runners and must write the requested PNG; prose-only results fail
+4. Use `--engine-hint imagen|grok|codex` when the host matters. `grok` maps to
+   the scriptable `grok-img` CLI, which needs `grok-img auth login` or
+   `XAI_API_KEY`. Codex must write the requested PNG; prose-only results fail
    closed with a retained prompt sidecar.
-5. If exit 2, no backend is on PATH. The prompt sidecar is already written. Run `/image-gen-install` or install grok/codex.
+5. If exit 2, no backend is on PATH. The prompt sidecar is already written. Run `/image-gen-install`, install `grok-img`, or use Codex.
 6. Integrate the PNG with 50–125 character ALT text.
 
 Do not invent a PNG. Do not send Mermaid or PlantUML through this command.

--- a/marketplace.json
+++ b/marketplace.json
@@ -13,8 +13,8 @@
     {
       "name": "image-gen",
       "source": "./",
-      "description": "Cover images and in-article illustrations. Latest imagen CLI, Nano Banana 2 / Pro, grok/codex fallback.",
-      "version": "2.0.0",
+      "description": "Cover images and in-article illustrations. Imagen direct adapter and Grok or Codex engine hints.",
+      "version": "2.1.0",
       "author": {
         "name": "Spillwave Solutions"
       },

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "image-gen",
-  "version": "2.0.0",
-  "description": "Generate cover images and in-article illustrations. Installs the latest imagen CLI, pins Nano Banana 2 / Pro, and falls back to grok then codex.",
+  "version": "2.1.0",
+  "description": "Generate cover images and in-article illustrations. Imagen direct adapter plus explicit Grok and Codex agent-engine hints with verified PNG output.",
   "author": {
     "name": "Spillwave Solutions",
     "email": "rick@spillwave.com",

--- a/skills/image-gen/SKILL.md
+++ b/skills/image-gen/SKILL.md
@@ -24,18 +24,19 @@ the caller has a preferred image engine. The hint selects that engine only. It
 does not pretend every installed command has a standalone image subcommand.
 
 - **Imagen:** calls the `imagen` CLI directly.
-- **Grok:** starts a Grok Build agent and asks it to use its native image tool.
+- **Grok:** calls `grok-img`, the noninteractive xAI image CLI. The plugin
+  normalizes the generated image to the requested output path.
 - **Codex:** starts a Codex agent and asks it to use `image_gen` when that host
   exposes the tool.
 
-Grok and Codex must write the requested PNG. A prose-only result fails closed
-and leaves the generated prompt sidecar for a manual retry. With no hint,
-`auto` tries each installed engine in order and falls through after a failed
-attempt, which lets an unauthenticated Imagen install reach another configured
-engine.
+Grok and Codex must write the requested PNG. A prose-only Codex result or a
+missing grok-img result fails closed and leaves the generated prompt sidecar for
+a manual retry. With no hint, `auto` tries each installed engine in order and
+falls through after a failed attempt, which lets an unauthenticated Imagen
+install reach another configured engine.
 
 1. `imagen` CLI if on PATH. Brace policy: `imagen-cli-vars` (double braces).
-2. Else `grok` CLI. Brace policy: `grok-imagine` (no rewrite).
+2. Then `grok-img` CLI. Brace policy: `grok-imagine` (no rewrite).
 3. Else `codex` CLI. Brace policy: `grok-imagine` (no rewrite).
 4. Else fail closed. Write `<stem>_imagen.prompt.txt` and exit 2.
 
@@ -93,7 +94,7 @@ python3 skills/image-gen/scripts/generate.py \
   --output work/images/article_workflow.png \
   --prompt "A clean technical diagram showing [concept] with color-coded arrows and clear labels. Style: blueprint, professional."
 
-# Ask a Grok Build host to generate through its native image tool.
+# Ask grok-img to generate with the configured xAI account.
 python3 skills/image-gen/scripts/generate.py \
   --kind article \
   --engine-hint grok \

--- a/skills/image-gen/SKILL.md
+++ b/skills/image-gen/SKILL.md
@@ -42,7 +42,28 @@ install reach another configured engine.
 
 Never invent a PNG. If no worker is installed, keep the prompt sidecar and tell the user to run `/image-gen-install`.
 
-## Install the imagen CLI
+## Install the Grok image CLI
+
+The `--engine-hint grok` adapter uses the noninteractive `grok-img` command,
+not Grok Build's interactive `/imagine` TUI. It needs Node.js 20.19 or newer
+and an xAI account with image-generation access.
+
+```bash
+npm install -g grok-image-cli
+grok-img --version
+grok-img auth login
+```
+
+Alternatively, configure the key noninteractively before running the skill:
+
+```bash
+export XAI_API_KEY="xai-..."
+```
+
+`grok-img` writes to a staging directory; `generate.py` selects its one result
+and copies it to the exact `--output` path.
+
+## Install the Imagen CLI
 
 Latest `gemini-imagen` (`imagen` on PATH) plus Nano Banana model pin:
 

--- a/skills/image-gen/SKILL.md
+++ b/skills/image-gen/SKILL.md
@@ -17,7 +17,22 @@ Use this skill when the user wants a cover image, in-article illustration, or vi
 
 Do not use this skill to render Mermaid or PlantUML. Send those to `imagen-diagrams`.
 
-## Backend (auto)
+## Image-engine hint and backend (auto)
+
+Use `--engine-hint imagen`, `--engine-hint grok`, or `--engine-hint codex` when
+the caller has a preferred image engine. The hint selects that engine only. It
+does not pretend every installed command has a standalone image subcommand.
+
+- **Imagen:** calls the `imagen` CLI directly.
+- **Grok:** starts a Grok Build agent and asks it to use its native image tool.
+- **Codex:** starts a Codex agent and asks it to use `image_gen` when that host
+  exposes the tool.
+
+Grok and Codex must write the requested PNG. A prose-only result fails closed
+and leaves the generated prompt sidecar for a manual retry. With no hint,
+`auto` tries each installed engine in order and falls through after a failed
+attempt, which lets an unauthenticated Imagen install reach another configured
+engine.
 
 1. `imagen` CLI if on PATH. Brace policy: `imagen-cli-vars` (double braces).
 2. Else `grok` CLI. Brace policy: `grok-imagine` (no rewrite).
@@ -77,6 +92,14 @@ python3 skills/image-gen/scripts/generate.py \
   --aspect 16:9 \
   --output work/images/article_workflow.png \
   --prompt "A clean technical diagram showing [concept] with color-coded arrows and clear labels. Style: blueprint, professional."
+
+# Ask a Grok Build host to generate through its native image tool.
+python3 skills/image-gen/scripts/generate.py \
+  --kind article \
+  --engine-hint grok \
+  --aspect 16:9 \
+  --output work/images/article_workflow.png \
+  --prompt "A clean technical diagram showing [concept]."
 ```
 
 ### 4. Integrate + ALT text

--- a/skills/image-gen/references/backends.md
+++ b/skills/image-gen/references/backends.md
@@ -3,11 +3,14 @@
 ## Auto order
 
 1. `imagen` if on PATH. Policy `imagen-cli-vars`.
-2. Else `grok` if on PATH. Policy `grok-imagine`.
-3. Else `codex` if on PATH. Policy `grok-imagine`.
+2. Then `grok` if on PATH. Policy `grok-imagine`.
+3. Then `codex` if on PATH. Policy `grok-imagine`.
 4. Else fail closed. Write `<stem>_imagen.prompt.txt` and exit 2.
 
-Pin with `--backend imagen|grok|codex|imagen-scan|auto`.
+Pin a runner with `--backend imagen|grok|codex|imagen-scan|auto`. Prefer an
+engine with `--engine-hint imagen|grok|codex`. A non-auto hint selects only
+that engine. Auto tries all installed engines until one writes the requested
+PNG.
 
 `imagen-scan` rewrites `{token}` to `(token)` for binaries that still scan the inner token.
 
@@ -23,7 +26,10 @@ A `{Decision?}` node or a JSON example in a prompt must not crash the imagen ada
 
 ## Why this exists
 
-`gemini-imagen` treats `{name}` as a template variable and runs `str.format`. A single brace in a prompt is a merge bug. Grok Imagine and Codex image generate do not. Copying the wrong escape is the first production failure.
+`gemini-imagen` treats `{name}` as a template variable and runs `str.format`.
+A single brace in a prompt is a merge bug. Grok Build and Codex agent prompts
+do not need the rewrite. Copying the wrong escape is the first production
+failure.
 
 ## Invocations
 
@@ -42,11 +48,17 @@ imagen generate --prompt-file FILE --aspect-ratio 16:9 -o OUT -m MODEL
 grok:
 
 ```text
-grok imagine generate --prompt-file FILE --aspect 16:9 --output OUT
+grok --cwd OUT_PARENT --prompt-file FILE --permission-mode auto
 ```
+
+The prompt tells Grok's native image tool to save exactly `OUT`. The adapter
+checks that the file exists after Grok exits.
 
 codex:
 
 ```text
-codex image generate --prompt-file FILE --aspect 16:9 --output OUT
+codex exec --skip-git-repo-check --ephemeral --add-dir OUT_PARENT -
 ```
+
+The prompt is passed on stdin and tells the Codex host to use `image_gen` and
+save exactly `OUT`. The adapter checks that the file exists after Codex exits.

--- a/skills/image-gen/references/backends.md
+++ b/skills/image-gen/references/backends.md
@@ -3,11 +3,11 @@
 ## Auto order
 
 1. `imagen` if on PATH. Policy `imagen-cli-vars`.
-2. Then `grok` if on PATH. Policy `grok-imagine`.
+2. Then `grok-img` if on PATH. Policy `grok-imagine`.
 3. Then `codex` if on PATH. Policy `grok-imagine`.
 4. Else fail closed. Write `<stem>_imagen.prompt.txt` and exit 2.
 
-Pin a runner with `--backend imagen|grok|codex|imagen-scan|auto`. Prefer an
+Pin a runner with `--backend imagen|grok-img|codex|imagen-scan|auto`. Prefer an
 engine with `--engine-hint imagen|grok|codex`. A non-auto hint selects only
 that engine. Auto tries all installed engines until one writes the requested
 PNG.
@@ -27,9 +27,8 @@ A `{Decision?}` node or a JSON example in a prompt must not crash the imagen ada
 ## Why this exists
 
 `gemini-imagen` treats `{name}` as a template variable and runs `str.format`.
-A single brace in a prompt is a merge bug. Grok Build and Codex agent prompts
-do not need the rewrite. Copying the wrong escape is the first production
-failure.
+A single brace in a prompt is a merge bug. grok-img and Codex agent prompts do
+not need the rewrite. Copying the wrong escape is the first production failure.
 
 ## Invocations
 
@@ -48,11 +47,13 @@ imagen generate --prompt-file FILE --aspect-ratio 16:9 -o OUT -m MODEL
 grok:
 
 ```text
-grok --cwd OUT_PARENT --prompt-file FILE --permission-mode auto
+grok-img generate PROMPT --aspect-ratio 16:9 --count 1 --output STAGING_DIR
 ```
 
-The prompt tells Grok's native image tool to save exactly `OUT`. The adapter
-checks that the file exists after Grok exits.
+The plugin stages grok-img output in an isolated directory, then copies the
+single generated image to `OUT`. `grok-img auth login` or `XAI_API_KEY` is
+required. The official Grok Build TUI `/imagine` command is interactive and is
+not the script adapter.
 
 codex:
 

--- a/skills/image-gen/scripts/backends.py
+++ b/skills/image-gen/scripts/backends.py
@@ -9,17 +9,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-BackendName = Literal["imagen", "grok", "codex"]
+BackendName = Literal["imagen", "grok-img", "codex"]
 BracePolicy = Literal["imagen-cli-vars", "imagen-cli-scan", "grok-imagine"]
 
 POLICY_FOR: dict[str, BracePolicy] = {
     "imagen": "imagen-cli-vars",
     "imagen-scan": "imagen-cli-scan",
-    "grok": "grok-imagine",
+    "grok-img": "grok-imagine",
     "codex": "grok-imagine",
 }
 
-AUTO_ORDER: tuple[BackendName, ...] = ("imagen", "grok", "codex")
+AUTO_ORDER: tuple[BackendName, ...] = ("imagen", "grok-img", "codex")
 
 
 @dataclass
@@ -62,11 +62,16 @@ def detect_backends(requested: str = "auto") -> list[ResolvedBackend]:
         if not path:
             return []
         return [ResolvedBackend("imagen", POLICY_FOR[requested], path)]
-    if requested in ("grok", "codex"):
-        path = shutil.which(requested)
+    if requested in ("grok", "grok-img"):
+        path = shutil.which("grok-img")
         if not path:
             return []
-        return [ResolvedBackend(requested, POLICY_FOR[requested], path)]  # type: ignore[arg-type]
+        return [ResolvedBackend("grok-img", POLICY_FOR["grok-img"], path)]
+    if requested == "codex":
+        path = shutil.which("codex")
+        if not path:
+            return []
+        return [ResolvedBackend("codex", POLICY_FOR["codex"], path)]
     resolved: list[ResolvedBackend] = []
     for name in AUTO_ORDER:
         path = shutil.which(name)
@@ -85,7 +90,7 @@ def argv_for(
     """Build the worker command. Prompt is always also on disk at prompt_file.
 
     imagen (gemini-imagen): positional/stdin prompt, -o, --aspect-ratio, -m
-    grok: Grok Build agent with a prompt file. It uses its native image tool.
+    grok-img: direct xAI image CLI, generated separately via grok_img_argv.
     codex: Codex agent running a prompt from stdin. It uses image_gen when
     the host makes that tool available.
     """
@@ -103,19 +108,6 @@ def argv_for(
         if model:
             cmd.extend(["-m", model])
         return cmd
-    if backend.name == "grok":
-        cmd = [
-            backend.binary,
-            "--cwd",
-            str(Path(out_file).resolve().parent),
-            "--prompt-file",
-            prompt_file,
-            "--permission-mode",
-            "auto",
-        ]
-        if model:
-            cmd.extend(["--model", model])
-        return cmd
     cmd: list[str] = [
         backend.binary,
         "exec",
@@ -127,6 +119,32 @@ def argv_for(
     ]
     if model:
         cmd[2:2] = ["--model", model]
+    return cmd
+
+
+def grok_img_argv(
+    backend: ResolvedBackend,
+    prompt: str,
+    output_dir: str,
+    aspect: str,
+    model: str | None = None,
+) -> list[str]:
+    """Build the documented grok-img invocation for a single new image."""
+    if backend.name != "grok-img":
+        raise ValueError("grok_img_argv requires a grok-img backend")
+    cmd = [
+        backend.binary,
+        "generate",
+        prompt,
+        "--aspect-ratio",
+        aspect,
+        "--count",
+        "1",
+        "--output",
+        output_dir,
+    ]
+    if model:
+        cmd.extend(["--model", model])
     return cmd
 
 

--- a/skills/image-gen/scripts/backends.py
+++ b/skills/image-gen/scripts/backends.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import re
 import shutil
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 BackendName = Literal["imagen", "grok", "codex"]
@@ -43,22 +44,35 @@ def escape_for_backend(text: str, policy: BracePolicy) -> str:
 
 
 def detect_backend(requested: str = "auto") -> ResolvedBackend | None:
+    """Resolve the first installed backend, retained for API compatibility."""
+    found = detect_backends(requested)
+    return found[0] if found else None
+
+
+def detect_backends(requested: str = "auto") -> list[ResolvedBackend]:
+    """Resolve all installed candidates in preference order.
+
+    Auto mode deliberately returns every usable command. A command existing on
+    PATH does not prove that it has credentials, so the renderer can fail over
+    when Imagen is installed but not configured.
+    """
     requested = (requested or "auto").strip().lower()
     if requested in ("imagen", "imagen-scan"):
         path = shutil.which("imagen")
         if not path:
-            return None
-        return ResolvedBackend("imagen", POLICY_FOR[requested], path)
+            return []
+        return [ResolvedBackend("imagen", POLICY_FOR[requested], path)]
     if requested in ("grok", "codex"):
         path = shutil.which(requested)
         if not path:
-            return None
-        return ResolvedBackend(requested, POLICY_FOR[requested], path)  # type: ignore[arg-type]
+            return []
+        return [ResolvedBackend(requested, POLICY_FOR[requested], path)]  # type: ignore[arg-type]
+    resolved: list[ResolvedBackend] = []
     for name in AUTO_ORDER:
         path = shutil.which(name)
         if path:
-            return ResolvedBackend(name, POLICY_FOR[name], path)
-    return None
+            resolved.append(ResolvedBackend(name, POLICY_FOR[name], path))
+    return resolved
 
 
 def argv_for(
@@ -71,8 +85,9 @@ def argv_for(
     """Build the worker command. Prompt is always also on disk at prompt_file.
 
     imagen (gemini-imagen): positional/stdin prompt, -o, --aspect-ratio, -m
-    grok: grok imagine generate --prompt-file --aspect --output
-    codex: codex image generate --prompt-file --aspect --output
+    grok: Grok Build agent with a prompt file. It uses its native image tool.
+    codex: Codex agent running a prompt from stdin. It uses image_gen when
+    the host makes that tool available.
     """
     if backend.name == "imagen":
         cmd = [
@@ -91,31 +106,27 @@ def argv_for(
     if backend.name == "grok":
         cmd = [
             backend.binary,
-            "imagine",
-            "generate",
+            "--cwd",
+            str(Path(out_file).resolve().parent),
             "--prompt-file",
             prompt_file,
-            "--aspect",
-            aspect,
-            "--output",
-            out_file,
+            "--permission-mode",
+            "auto",
         ]
         if model:
             cmd.extend(["--model", model])
         return cmd
-    cmd = [
+    cmd: list[str] = [
         backend.binary,
-        "image",
-        "generate",
-        "--prompt-file",
-        prompt_file,
-        "--aspect",
-        aspect,
-        "--output",
-        out_file,
+        "exec",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "--add-dir",
+        str(Path(out_file).resolve().parent),
+        "-",
     ]
     if model:
-        cmd.extend(["--model", model])
+        cmd[2:2] = ["--model", model]
     return cmd
 
 

--- a/skills/image-gen/scripts/generate.py
+++ b/skills/image-gen/scripts/generate.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from backends import (
     argv_for,
-    detect_backend,
+    detect_backends,
     escape_for_backend,
     imagen_fallback_argv,
 )
@@ -75,11 +75,31 @@ def run_backend(
     if dry_run:
         return 0
     try:
-        proc = subprocess.run(cmd, check=False)
+        agent_host = resolved.name in {"grok", "codex"}
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            input=prompt if resolved.name == "codex" else None,
+            text=agent_host,
+            capture_output=agent_host,
+        )
     except FileNotFoundError:
         print(f"backend binary missing: {resolved.binary}", file=sys.stderr)
         return 2
-    return proc.returncode
+    if proc.returncode != 0:
+        if agent_host:
+            diagnostics = ((proc.stdout or "") + (proc.stderr or "")).strip()
+            if diagnostics:
+                print(diagnostics[-2000:], file=sys.stderr)
+        return proc.returncode
+    if resolved.name in {"grok", "codex"} and not out.exists():
+        print(
+            f"{resolved.name} exited without writing {out}. "
+            "Prompt kept for manual retry.",
+            file=sys.stderr,
+        )
+        return 4
+    return 0
 
 
 def _redact_prompt(cmd: list[str]) -> list[str]:
@@ -90,6 +110,19 @@ def _redact_prompt(cmd: list[str]) -> list[str]:
     return out
 
 
+def agent_prompt(engine: str, prompt: str, out: Path, aspect: str) -> str:
+    """Ask an agent host to create a file, instead of pretending it has a CLI subcommand."""
+    return "\n\n".join(
+        [
+            f"Use your native {engine} image-generation capability to create one final PNG.",
+            f"Save the PNG exactly at: {out}",
+            f"Aspect ratio: {aspect}. Do not return prose only. Do not change the path.",
+            "Image brief:",
+            prompt,
+        ]
+    )
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description="image-gen article image renderer")
     p.add_argument("--prompt", help="Image prompt text")
@@ -98,6 +131,12 @@ def main() -> int:
     p.add_argument("--kind", choices=("cover", "article", "default"), default="default")
     p.add_argument("--aspect", default="16:9")
     p.add_argument("--backend", default="auto")
+    p.add_argument(
+        "--engine-hint",
+        choices=("auto", "imagen", "grok", "codex"),
+        default="auto",
+        help="Prefer this image engine. In auto mode, failed workers fall through to the next installed engine.",
+    )
     p.add_argument("--model", help="Model id or alias (nano-banana-2, nano-banana-pro, ...)")
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
@@ -117,27 +156,27 @@ def main() -> int:
     sidecar = out.with_suffix(".json")
     prompt_file = prompt_path_for(out)
 
-    resolved = detect_backend(args.backend)
-    policy = resolved.policy if resolved else "imagen-cli-vars"
-    escaped = escape_for_backend(prompt, policy)
-    prompt_file.write_text(escaped, encoding="utf-8")
-
-    model = resolve_model(args.model, kind=args.kind) if resolved and resolved.name == "imagen" else args.model
-    if resolved and resolved.name == "imagen" and not model:
-        model = DEFAULT_MODEL_ID
-
+    if args.backend != "auto" and args.engine_hint != "auto":
+        p.error("Use either --backend or --engine-hint, not both.")
+    requested = args.engine_hint if args.engine_hint != "auto" else args.backend
+    resolved_backends = detect_backends(requested)
     sidecar_data = {
         "png": str(out),
         "prompt": str(prompt_file),
         "kind": args.kind,
         "aspect": args.aspect,
-        "backend": resolved.name if resolved else None,
-        "policy": policy,
-        "model": model,
+        "engine_hint": args.engine_hint,
+        "backend": None,
+        "policy": "imagen-cli-vars",
+        "model": args.model,
+        "attempts": [],
     }
-    sidecar.write_text(json.dumps(sidecar_data, indent=2) + "\n", encoding="utf-8")
 
-    if not resolved:
+    if not resolved_backends:
+        prompt_file.write_text(
+            escape_for_backend(prompt, "imagen-cli-vars"), encoding="utf-8"
+        )
+        sidecar.write_text(json.dumps(sidecar_data, indent=2) + "\n", encoding="utf-8")
         print(
             "No image backend on PATH (imagen, grok, or codex). "
             f"Wrote prompt to {prompt_file}.",
@@ -145,22 +184,48 @@ def main() -> int:
         )
         return 2
 
-    code = run_backend(
-        resolved,
-        escaped,
-        prompt_file,
-        out,
-        args.aspect,
-        model,
-        args.dry_run,
-    )
-    if code != 0:
-        print(
-            f"backend exited {code}. Prompt kept at {prompt_file}.",
-            file=sys.stderr,
+    last_code = 2
+    for resolved in resolved_backends:
+        policy = resolved.policy
+        worker_prompt = (
+            prompt
+            if resolved.name == "imagen"
+            else agent_prompt(resolved.name, prompt, out, args.aspect)
         )
-        return code if code != 0 else 2
-    return 0
+        escaped = escape_for_backend(worker_prompt, policy)
+        prompt_file.write_text(escaped, encoding="utf-8")
+        model = (
+            resolve_model(args.model, kind=args.kind)
+            if resolved.name == "imagen"
+            else args.model
+        )
+        if resolved.name == "imagen" and not model:
+            model = DEFAULT_MODEL_ID
+        code = run_backend(
+            resolved,
+            escaped,
+            prompt_file,
+            out,
+            args.aspect,
+            model,
+            args.dry_run,
+        )
+        sidecar_data.update(
+            {
+                "backend": resolved.name,
+                "policy": policy,
+                "model": model,
+            }
+        )
+        sidecar_data["attempts"].append({"backend": resolved.name, "exit_code": code})
+        sidecar.write_text(json.dumps(sidecar_data, indent=2) + "\n", encoding="utf-8")
+        if code == 0:
+            return 0
+        last_code = code
+        if requested != "auto":
+            break
+    print(f"all image backends failed. Prompt kept at {prompt_file}.", file=sys.stderr)
+    return last_code
 
 
 if __name__ == "__main__":

--- a/skills/image-gen/scripts/generate.py
+++ b/skills/image-gen/scripts/generate.py
@@ -3,7 +3,7 @@
 
 Backend order (auto):
 1. imagen on PATH. Policy imagen-cli-vars.
-2. Else grok on PATH. Policy grok-imagine.
+2. Then grok-img on PATH. Policy grok-imagine.
 3. Else codex on PATH. Policy grok-imagine.
 4. Else fail closed. Write <stem>_imagen.prompt.txt and exit 2.
 """
@@ -12,19 +12,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from backends import (
     argv_for,
     detect_backends,
     escape_for_backend,
+    grok_img_argv,
     imagen_fallback_argv,
 )
 from models import DEFAULT_MODEL_ID, resolve_model
 
 SCRIPTS = Path(__file__).resolve().parent
+GROK_IMG_DEFAULT_MODEL = "grok-imagine-image"
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
 
 
 def prompt_path_for(output: Path) -> Path:
@@ -63,6 +68,29 @@ def run_backend(
     model: str | None,
     dry_run: bool,
 ) -> int:
+    if resolved.name == "grok-img":
+        stage = Path(tempfile.mkdtemp(prefix=f".{out.stem}.grok-img-", dir=out.parent))
+        try:
+            cmd = grok_img_argv(resolved, prompt, str(stage), aspect, model=model)
+            print(" ".join(_redact_prompt(cmd)))
+            if dry_run:
+                return 0
+            proc = subprocess.run(cmd, check=False)
+            if proc.returncode != 0:
+                return proc.returncode
+            generated = sorted(
+                (path for path in stage.rglob("*") if path.suffix.lower() in IMAGE_EXTENSIONS),
+                key=lambda path: path.stat().st_mtime,
+                reverse=True,
+            )
+            if not generated:
+                print("grok-img exited without writing an image.", file=sys.stderr)
+                return 4
+            shutil.copy2(generated[0], out)
+            return 0
+        finally:
+            shutil.rmtree(stage, ignore_errors=True)
+
     if resolved.name == "imagen" and not imagen_supports_prompt_file(resolved.binary):
         cmd = imagen_fallback_argv(
             resolved, prompt, str(out), aspect, model=model
@@ -75,7 +103,7 @@ def run_backend(
     if dry_run:
         return 0
     try:
-        agent_host = resolved.name in {"grok", "codex"}
+        agent_host = resolved.name == "codex"
         proc = subprocess.run(
             cmd,
             check=False,
@@ -92,7 +120,7 @@ def run_backend(
             if diagnostics:
                 print(diagnostics[-2000:], file=sys.stderr)
         return proc.returncode
-    if resolved.name in {"grok", "codex"} and not out.exists():
+    if resolved.name == "codex" and not out.exists():
         print(
             f"{resolved.name} exited without writing {out}. "
             "Prompt kept for manual retry.",
@@ -178,7 +206,7 @@ def main() -> int:
         )
         sidecar.write_text(json.dumps(sidecar_data, indent=2) + "\n", encoding="utf-8")
         print(
-            "No image backend on PATH (imagen, grok, or codex). "
+            "No image backend on PATH (imagen, grok-img, or codex). "
             f"Wrote prompt to {prompt_file}.",
             file=sys.stderr,
         )
@@ -189,7 +217,7 @@ def main() -> int:
         policy = resolved.policy
         worker_prompt = (
             prompt
-            if resolved.name == "imagen"
+            if resolved.name != "codex"
             else agent_prompt(resolved.name, prompt, out, args.aspect)
         )
         escaped = escape_for_backend(worker_prompt, policy)
@@ -201,6 +229,8 @@ def main() -> int:
         )
         if resolved.name == "imagen" and not model:
             model = DEFAULT_MODEL_ID
+        if resolved.name == "grok-img" and not model:
+            model = GROK_IMG_DEFAULT_MODEL
         code = run_backend(
             resolved,
             escaped,

--- a/tests/test_backend_detect.py
+++ b/tests/test_backend_detect.py
@@ -11,6 +11,7 @@ from backends import (  # noqa: E402
     argv_for,
     detect_backend,
     detect_backends,
+    grok_img_argv,
     imagen_fallback_argv,
 )
 
@@ -28,11 +29,11 @@ class DetectTests(unittest.TestCase):
 
     def test_auto_falls_to_grok(self):
         def which(name):
-            return {"grok": "/usr/bin/grok", "codex": "/usr/bin/codex"}.get(name)
+            return {"grok-img": "/usr/bin/grok-img", "codex": "/usr/bin/codex"}.get(name)
 
         with patch("backends.shutil.which", side_effect=which):
             resolved = detect_backend("auto")
-        self.assertEqual(resolved.name, "grok")
+        self.assertEqual(resolved.name, "grok-img")
         self.assertEqual(resolved.policy, "grok-imagine")
 
     def test_auto_falls_to_codex(self):
@@ -50,11 +51,11 @@ class DetectTests(unittest.TestCase):
 
     def test_auto_returns_all_candidates_for_runtime_failover(self):
         def which(name):
-            return {"imagen": "/usr/bin/imagen", "grok": "/usr/bin/grok"}.get(name)
+            return {"imagen": "/usr/bin/imagen", "grok-img": "/usr/bin/grok-img"}.get(name)
 
         with patch("backends.shutil.which", side_effect=which):
             resolved = detect_backends("auto")
-        self.assertEqual([item.name for item in resolved], ["imagen", "grok"])
+        self.assertEqual([item.name for item in resolved], ["imagen", "grok-img"])
 
     def test_imagen_argv_uses_prompt_file_and_model(self):
         def which(name):
@@ -92,23 +93,25 @@ class DetectTests(unittest.TestCase):
             ],
         )
 
-    def test_grok_argv(self):
+    def test_grok_img_argv(self):
         def which(name):
-            return "/usr/bin/grok" if name == "grok" else None
+            return "/usr/bin/grok-img" if name == "grok-img" else None
 
         with patch("backends.shutil.which", side_effect=which):
             resolved = detect_backend("grok")
-        cmd = argv_for(resolved, "p.txt", "out.png", "16:9")
+        cmd = grok_img_argv(resolved, "a diagram", "out-dir", "16:9")
         self.assertEqual(
             cmd,
             [
-                "/usr/bin/grok",
-                "--cwd",
-                str(Path("out.png").resolve().parent),
-                "--prompt-file",
-                "p.txt",
-                "--permission-mode",
-                "auto",
+                "/usr/bin/grok-img",
+                "generate",
+                "a diagram",
+                "--aspect-ratio",
+                "16:9",
+                "--count",
+                "1",
+                "--output",
+                "out-dir",
             ],
         )
 

--- a/tests/test_backend_detect.py
+++ b/tests/test_backend_detect.py
@@ -6,7 +6,13 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills/image-gen/scripts"))
 
-from backends import argv_for, detect_backend, imagen_fallback_argv  # noqa: E402
+from backends import (  # noqa: E402
+    ResolvedBackend,
+    argv_for,
+    detect_backend,
+    detect_backends,
+    imagen_fallback_argv,
+)
 
 
 class DetectTests(unittest.TestCase):
@@ -41,6 +47,14 @@ class DetectTests(unittest.TestCase):
     def test_none_when_missing(self):
         with patch("backends.shutil.which", return_value=None):
             self.assertIsNone(detect_backend("auto"))
+
+    def test_auto_returns_all_candidates_for_runtime_failover(self):
+        def which(name):
+            return {"imagen": "/usr/bin/imagen", "grok": "/usr/bin/grok"}.get(name)
+
+        with patch("backends.shutil.which", side_effect=which):
+            resolved = detect_backends("auto")
+        self.assertEqual([item.name for item in resolved], ["imagen", "grok"])
 
     def test_imagen_argv_uses_prompt_file_and_model(self):
         def which(name):
@@ -89,16 +103,20 @@ class DetectTests(unittest.TestCase):
             cmd,
             [
                 "/usr/bin/grok",
-                "imagine",
-                "generate",
+                "--cwd",
+                str(Path("out.png").resolve().parent),
                 "--prompt-file",
                 "p.txt",
-                "--aspect",
-                "16:9",
-                "--output",
-                "out.png",
+                "--permission-mode",
+                "auto",
             ],
         )
+
+    def test_codex_argv_runs_an_agent_not_a_missing_image_subcommand(self):
+        backend = ResolvedBackend("codex", "grok-imagine", "/usr/bin/codex")
+        cmd = argv_for(backend, "p.txt", "out.png", "16:9")
+        self.assertEqual(cmd[0:4], ["/usr/bin/codex", "exec", "--skip-git-repo-check", "--ephemeral"])
+        self.assertIn("-", cmd)
 
 
 if __name__ == "__main__":

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -82,7 +82,7 @@ class GenerateTests(unittest.TestCase):
                 "grok",
                 "--dry-run",
             ]
-            backend = ResolvedBackend("grok", "grok-imagine", "/usr/bin/grok")
+            backend = ResolvedBackend("grok-img", "grok-imagine", "/usr/bin/grok-img")
             with patch.object(sys, "argv", argv), patch(
                 "generate.detect_backends", return_value=[backend]
             ), patch("generate.subprocess.run") as run:
@@ -91,9 +91,32 @@ class GenerateTests(unittest.TestCase):
             run.assert_not_called()
             data = json.loads((Path(tmp) / "diagram.json").read_text(encoding="utf-8"))
             self.assertEqual(data["engine_hint"], "grok")
-            self.assertEqual(data["backend"], "grok")
+            self.assertEqual(data["backend"], "grok-img")
             prompt = (Path(tmp) / "diagram_imagen.prompt.txt").read_text(encoding="utf-8")
-            self.assertIn("Save the PNG exactly at", prompt)
+            self.assertEqual(prompt, "technical diagram")
+
+    def test_grok_img_normalizes_generated_file_to_requested_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "diagram.png"
+            backend = ResolvedBackend("grok-img", "grok-imagine", "/usr/bin/grok-img")
+
+            def generate_file(cmd, check):
+                destination = Path(cmd[cmd.index("--output") + 1]) / "result.jpeg"
+                destination.write_bytes(b"generated-image")
+                return type("Result", (), {"returncode": 0})()
+
+            with patch("generate.subprocess.run", side_effect=generate_file):
+                code = generate.run_backend(
+                    backend,
+                    "technical diagram",
+                    Path(tmp) / "diagram_imagen.prompt.txt",
+                    out,
+                    "16:9",
+                    "grok-imagine-image",
+                    False,
+                )
+            self.assertEqual(code, 0)
+            self.assertEqual(out.read_bytes(), b"generated-image")
 
 
 if __name__ == "__main__":

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -34,7 +34,7 @@ class GenerateTests(unittest.TestCase):
                 str(out),
             ]
             with patch.object(sys, "argv", argv), patch(
-                "generate.detect_backend", return_value=None
+                "generate.detect_backends", return_value=[]
             ):
                 code = generate.main()
             self.assertEqual(code, 2)
@@ -60,7 +60,7 @@ class GenerateTests(unittest.TestCase):
             ]
             backend = ResolvedBackend("imagen", "imagen-cli-vars", "/usr/bin/imagen")
             with patch.object(sys, "argv", argv), patch(
-                "generate.detect_backend", return_value=backend
+                "generate.detect_backends", return_value=[backend]
             ), patch("generate.imagen_supports_prompt_file", return_value=False), patch(
                 "generate.subprocess.run"
             ) as run:
@@ -68,6 +68,32 @@ class GenerateTests(unittest.TestCase):
             self.assertEqual(code, 0)
             run.assert_not_called()  # dry-run prints but does not execute
             self.assertTrue((Path(tmp) / "diagram_imagen.prompt.txt").exists())
+
+    def test_engine_hint_selects_grok_and_records_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "diagram.png"
+            argv = [
+                "generate.py",
+                "--prompt",
+                "technical diagram",
+                "--output",
+                str(out),
+                "--engine-hint",
+                "grok",
+                "--dry-run",
+            ]
+            backend = ResolvedBackend("grok", "grok-imagine", "/usr/bin/grok")
+            with patch.object(sys, "argv", argv), patch(
+                "generate.detect_backends", return_value=[backend]
+            ), patch("generate.subprocess.run") as run:
+                code = generate.main()
+            self.assertEqual(code, 0)
+            run.assert_not_called()
+            data = json.loads((Path(tmp) / "diagram.json").read_text(encoding="utf-8"))
+            self.assertEqual(data["engine_hint"], "grok")
+            self.assertEqual(data["backend"], "grok")
+            prompt = (Path(tmp) / "diagram_imagen.prompt.txt").read_text(encoding="utf-8")
+            self.assertIn("Save the PNG exactly at", prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- add --engine-hint imagen|grok|codex and runtime backend failover\n- map the Grok hint to the scriptable grok-img CLI, normalize its staged result to the requested output path, and verify the file exists\n- invoke Codex as an agent host, verify that it writes the requested PNG, and replace obsolete guessed image subcommands\n\n## Validation\n- python3 -m unittest discover -s tests -v\n- live Codex engine-hint run wrote a PNG successfully\n- grok-img adapter construction and output-path normalization are covered by tests